### PR TITLE
Changed file path handling, this way globbing also works

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function(options) {
       }
     }
     file.contents = new Buffer(JSON5.stringify(obj, null, options['beautify'] ? 4 : null));
-    file.path = path.join(file.base, path.basename(file.path, path.extname(file.path)) + '.json');
+    file.path = file.path.replace(/\.json5$/, '.json');
     callback(null, file);
   }
 


### PR DESCRIPTION
This places the resulting .json file next to the original .json5 file:

return gulp.src('./path/to/somewhere/*_/_.json5')
        .pipe(json5({
            beautify: true // default
        }))
        .pipe(gulp.dest('./path/to/somewhere/'));
