### PR TITLE
improving error treatment

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function(options) {
       }
     }
     file.contents = new Buffer(JSON5.stringify(obj, null, options['beautify'] ? 4 : null));
-    file.path = path.join(file.base, path.basename(file.path, path.extname(file.path)) + '.json');
+    file.path = path.join(path.dirname(file.path), path.basename(file.path, path.extname(file.path)) + '.json');    
     callback(null, file);
   }
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,14 @@ module.exports = function(options) {
       try {
         obj = JSON5.parse(file.contents + '');
       } catch (err) {
-        throw new PluginError(PLUGIN_NAME, "JSON5 parser error", err);
+        // Find the line causing error
+        var pos, line, lines = err.text.split(/\n/);
+        for (pos = 0, line = 0; pos < err.at && line < lines.length; line++) {
+          pos += lines[line].length;
+        }
+        // Report the error using a gcc message format like
+        // When the file content is a single line, displays the position instead of the line.
+        throw new PluginError(PLUGIN_NAME, file.relative  + ':' + (line || err.at) + ': ' + err.message);
       }
     }
     file.contents = new Buffer(JSON5.stringify(obj, null, options['beautify'] ? 4 : null));


### PR DESCRIPTION
1. Improving error treatment by displaying the file name, the line number (when possible) and the error message returned by the parser.
2. bug fix: file paths when using *_/_.json5

Example:

```
  gulp.src(‘data/**/*.json5')
    .pipe(json5())
    .pipe(gulp.dest(‘dist’));
```

with:

```
  data/file1.json5
  data/folder1/file2.json5
```

before:

```
  dist/file1.json5
  dist/file2.json5
```

after the fix:

```
  dist/file1.json5
  dist/folder1/file2.json5
```
