### PR TITLE
Make plugin work on case-sensitive systems

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var path = require('path');
 var gutil = require('gulp-util');
 var map = require('map-stream');
-var JSON5 = require('JSON5');
+var JSON5 = require('json5');
 
 var PluginError = gutil.PluginError;
 


### PR DESCRIPTION
JSON5 package is published as `json5` not `JSON5` to npm.
Requiring it as `JSON5` make case-sensitive systems fail
