### PR TITLE
Output strict JSON as advertised

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function(options) {
         throw new PluginError(PLUGIN_NAME, "JSON5 parser error", err);
       }
     }
-    file.contents = new Buffer(JSON5.stringify(obj, null, options['beautify'] ? 4 : null));
+    file.contents = new Buffer(JSON.stringify(obj, null, options['beautify'] ? 4 : null));
     file.path = file.path.replace(/\.json5$/, '.json');
     callback(null, file);
   }


### PR DESCRIPTION
Code as-is appears to outputting JSON5 data, which fails to go through `JSON.parse` or `require`.